### PR TITLE
signup endpoint done

### DIFF
--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -1,5 +1,46 @@
+import User from "../models/User.js";
+import jwt from "jsonwebtoken";
 export async function signup(req,res) {
-    res.send("Signup Route");
+    const {email, password, fullName}= req.body;
+
+    try{
+        if(!email || !password || !fullName){
+           return res.status(400).json({ message: "All fields are required"});
+        }
+        if(password.length < 7){
+            return res.status(400).json({message: "Password must be atleast 7 characters long"})
+        }
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+        if (!emailRegex.test(email)) {
+        return res.status(400).json({ message: "Email format is invalid" });
+        }
+
+        const existingUser = await User.findOne({email});
+        if(existingUser){
+            return res.status(400).json({message: "Email already exists, please use a different one"})
+        }
+        const idx = Math.floor(Math.random() * 100) + 1;
+        const randomAvatar = `https://avatar.iran.liara.run/public/${idx}.png`;
+        const newUser = await User.create({email, fullName, password, profilePic: randomAvatar, })
+
+        const token = jwt.sign({userId: newUser._id}, process.env.JWT_SECRET_KEY, {expiresIn: '7d',})
+
+        res.cookie("jwt", token, {
+            maxAge: 7 * 24 * 60 * 1000,
+            httpOnly: true,
+            sameSite: "strict",
+            secure: process.env.NODE_ENV==="production"
+        })
+
+        res.status(201).json({success: true, user:newUser})
+
+
+    } catch(error){
+        console.log("Error in signup controller", error)
+        res.status(500).json({message: "Internal Server Error"});
+
+    }
 }
 export async function login(req,res) {
     res.send("Login Route");

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,0 +1,62 @@
+import mongoose from "mongoose";
+import bcrypt from "bcryptjs"
+
+const userSchema = new mongoose.Schema({
+    fullName:{
+        type: String,
+        required: true,
+    }, 
+    email: {
+        type: String,
+        required: true,
+        unique: true,
+    }, 
+    password: {
+        type: String, 
+        minlength : 7, 
+    }, 
+    bio: {
+        type : String, 
+        default: "",
+    }, 
+    profilePic: {
+        type : String, 
+        default: "",
+    }, 
+    yourBeliefsPhilosophy: {
+        type: String, 
+        default: "",
+    }, 
+    curiousAbout: {
+        type: String, 
+        default: "",
+    }, 
+    location: { 
+        type: String, 
+        default: "",
+    }, 
+    isOnboarded: {
+        type: Boolean, 
+        default: false,
+    }, 
+    friends: [{
+        type: mongoose.Schema.Types.ObjectId, ref: 'User',}] 
+}, 
+{timestamps:true});
+userSchema.pre("save", async function(next) {
+    if(!this.isModified("password")) return next();
+    try{
+        const salt = await bcrypt.genSalt(10);
+        this.password = await bcrypt.hash(this.password, salt);
+
+        next();
+    } catch(error){
+        next(error);
+    }
+
+});
+const User = mongoose.model("User", userSchema);
+
+
+
+export default User;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -7,6 +7,8 @@ const app = express();
 
 const PORT = process.env.PORT;
 
+app.use(express.json());
+
 
 
 app.use("/api/auth", authRoutes);


### PR DESCRIPTION
feat(auth): implement signup endpoint & user model

- add Mongoose User schema (fullName, email, hashed password + pre-save bcrypt hook)
- implement signup controller with:
  • field presence & password-length validation
  • email format & uniqueness checks
  • new user creation (with random avatar)
  • JWT issuance and HttpOnly cookie via JWT_SECRET_KEY