### PR TITLE
feat: add login/logout endpoints & integrate Stream user upsert

### DIFF
--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -1,3 +1,4 @@
+import { upsertStreamUser } from "../lib/stream.js";
 import User from "../models/User.js";
 import jwt from "jsonwebtoken";
 export async function signup(req,res) {
@@ -23,15 +24,27 @@ export async function signup(req,res) {
         const idx = Math.floor(Math.random() * 100) + 1;
         const randomAvatar = `https://avatar.iran.liara.run/public/${idx}.png`;
         const newUser = await User.create({email, fullName, password, profilePic: randomAvatar, })
+        try{
+            await upsertStreamUser({
+                id: newUser._id.toString(),
+                name: newUser.fullName,
+                image: newUser.profilePic || "",
+            });
+            console.log(`Stream user created for ${newUser.fullName}`);
+        }catch(error){
+            console.log("Error creating Stream user:", error)
+        }
 
-        const token = jwt.sign({userId: newUser._id}, process.env.JWT_SECRET_KEY, {expiresIn: '7d',})
+        const token = jwt.sign({userId: newUser._id}, process.env.JWT_SECRET_KEY, 
+            {expiresIn: '7d',
+            });
 
         res.cookie("jwt", token, {
             maxAge: 7 * 24 * 60 * 1000,
             httpOnly: true,
             sameSite: "strict",
             secure: process.env.NODE_ENV==="production"
-        })
+        });
 
         res.status(201).json({success: true, user:newUser})
 
@@ -43,8 +56,37 @@ export async function signup(req,res) {
     }
 }
 export async function login(req,res) {
-    res.send("Login Route");
+    try{    
+        const { email, password} = req.body;
+        if (!email || !password){
+            return res.status(400).json({message: "All fields are required"});
+        }
+        const user = await User.findOne({email});
+        if (!user) return res.status(401).json({message: "invalid email or password"});
+
+        const isPasswordCorrect = await user.matchPassword(password);
+        if(!isPasswordCorrect) return res.status(401).json({ message: "invalid email or password"});
+
+        const token = jwt.sign({userId: user._id}, process.env.JWT_SECRET_KEY, {
+            expiresIn: '7d',
+            });
+
+        res.cookie("jwt", token, {
+            maxAge: 7 * 24 * 60 * 60 * 1000,
+            httpOnly: true,
+            sameSite: "strict",
+            secure: process.env.NODE_ENV==="production"
+        });  
+        res.status(200).json({ success: true, user});
+
+    }   catch (error){
+        console.log("error in login controller", error.message);
+        res.status(500).json({ message: "internal server error"});
+
+    }
+
 }
 export function logout(req,res) {
-    res.send("Logout Route");
+    res.clearCookie("jwt")
+    res.status(200).json({ success: true, message: "Logout successful"});
 }

--- a/backend/src/lib/stream.js
+++ b/backend/src/lib/stream.js
@@ -1,0 +1,23 @@
+import {StreamChat} from "stream-chat"
+
+import "dotenv/config"
+
+const apiKey = process.env.STEAM_API_KEY
+const apiSecret = process.env.STEAM_API_SECRET
+
+if (!apiKey || !apiSecret) {
+    console.error("Stream API key or Secret is missing")
+}
+const streamClient = StreamChat.getInstance(apiKey, apiSecret);
+
+export const upsertStreamUser = async (userData) => {
+    try{
+        await streamClient.upsertUsers([userData]); //upsert = create or update user depending on if it exists or not
+        return userData
+    }catch(error){
+        console.error("Error upserting Stream user:", error);
+
+    }
+};
+//gonna do this later
+export const generateStreamToken = (userId) => {}

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -55,6 +55,12 @@ userSchema.pre("save", async function(next) {
     }
 
 });
+
+userSchema.methods.matchPassword = async function (enteredPassword){
+    const isPasswordCorrect = await bcrypt.compare(enteredPassword, this.password);
+    return isPasswordCorrect;
+
+}
 const User = mongoose.model("User", userSchema);
 
 


### PR DESCRIPTION
**Signup**

- Creates a new User document in MongoDB

- Calls upsertStreamUser to register/reconcile the user in Stream Chat (errors are logged but do not block signup)

- Signs a JWT and sets it as an HttpOnly cookie

**Login**

- Checks for email & password in the request body

- Verifies the password hash via user.matchPassword
 
- Returns 401 Invalid email or password on failure

- Signs a JWT and sets it as an HttpOnly cookie on success

**Logout**

- Clears the jwt cookie and returns a success message

**Stream helper (lib/stream.js)**

- Initializes the StreamChat client using STREAM_API_KEY / STREAM_API_SECRET


- Exports upsertStreamUser(userData) to upsert users in Stream Chat

_This completes the core auth flow (signup, login, logout) and hooks our users into Stream Chat._