### PR TITLE
feat(auth): add route protection and user endpoints, onboarding flow with stream upsert

### DIFF
--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -90,3 +90,38 @@ export function logout(req,res) {
     res.clearCookie("jwt")
     res.status(200).json({ success: true, message: "Logout successful"});
 }
+export async function onboard(req, res) {
+    try{
+        const userId = req.user._id 
+        const {fullName, bio, yourBeliefsPhilosophy, curiousAbout, location} = req.body;
+        if ( !fullName || !bio || !yourBeliefsPhilosophy || !curiousAbout || !location){
+            return res.status(400).json({message: "All fields are required",
+                missingFields: [
+                    !fullName && "fullName",
+                    !bio && "bio",
+                    !yourBeliefsPhilosophy && "yourBeliefsPhilosophy",
+                    !curiousAbout && "curiousAbout",
+                    !location && "location",
+
+                ].filter(Boolean),
+            });
+        }
+
+        const updatedUser = await User.findByIdAndUpdate(userId, { ...req.body, isOnboarded: true,  },{new:true });
+
+        if (!updatedUser) return res.status(404).json({message: "User not found"});
+        try{
+        await upsertStreamUser({id: updatedUser._id.toString(), name: updatedUser.fullName, 
+            image: updatedUser.profilePic || "", });
+            console.log(`Stream user updated after onboarding for ${updatedUser.fullName}`);
+        } catch (streamError){
+            console.log("Error updating Stream user during onboarding:", streamError.message);
+        }
+
+            res.status(200).json({ success: true, user: updatedUser});
+    }   catch(error) {
+        console.error("Onboarding error:", error);
+        res.status(500).json({ message: "Internal Server Error"});
+
+    }
+}

--- a/backend/src/middleware/auth.middleware.js
+++ b/backend/src/middleware/auth.middleware.js
@@ -1,0 +1,30 @@
+import jwt from "jsonwebtoken";
+import User from "../models/User.js";
+
+
+export const protectRoute = async (req, res, next) => { 
+
+    try{
+
+        const token = req.cookies.jwt;
+
+        if(!token) {
+            return res.status(401).json({ message: "Unauthorized - No token provided" });
+        }
+        const decoded = jwt.verify(token, process.env.JWT_SECRET_KEY);
+        if(!token){
+            return res.status(401).json({ message: "Unauthorized - Invalid token"});
+        }
+        const user = await User.findById(decoded.userId).select("-password");
+        if(!user){
+            return res.status(401).json({ message: "Unauthorized - User not found"})
+        }
+        req.user = user;
+        next()
+
+    } catch(error) {
+        console.log("Error in protectRoute middleware", error);
+        res.status(500).json({ message: "Internal Server Error"});
+    }
+
+};

--- a/backend/src/routes/auth.route.js
+++ b/backend/src/routes/auth.route.js
@@ -1,11 +1,16 @@
 import express, { Router } from "express"
-import { login, logout, signup } from "../controllers/auth.controller.js";
-
+import { login, logout, signup , onboard} from "../controllers/auth.controller.js";
+import { protectRoute } from "../middleware/auth.middleware.js"; 
 const router = express.Router();
 
 router.post("/signup", signup);
 router.post("/login", login);
-router.post("/logout", logout);
+router.post("/logout", logout);//post because post methods are for operations that change the server state (e.g logging out destroys a session and invalidates a token)
 
+router.post("/onboarding", protectRoute, onboard);
+//checks if user is logged in or not
+router.get("/me", protectRoute, (req, res) => {
+    res.status(200).json({ success: true, user: req.user});
+});
 
 export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,6 +1,8 @@
 import express from "express";
 import "dotenv/config";
+import cookieParser from "cookie-parser";
 import authRoutes from "./routes/auth.route.js";
+
 import { connectDB } from "./lib/db.js";
 
 const app = express();
@@ -8,6 +10,7 @@ const app = express();
 const PORT = process.env.PORT;
 
 app.use(express.json());
+app.use(cookieParser());
 
 
 


### PR DESCRIPTION
After signing up, users are redirected to the onboarding page to fill out or update their profile (bio, location, yourBeliefsPhilosophy, curiousAbout ,full name, profile image). Because these operations modify user data, the onboarding and profile‐check routes must be protected so only logged‐in users can access them.

Returns 400 with a missingFields array if any are blank

Updates user document (isOnboarded: true) and returns the updated user

Calls upsertStreamUser to sync profile changes to Stream Chat (errors are logged but don’t block the response)

**Authentication flow**
On signup and login, we issue a JWT and set it in an HttpOnly cookie (jwt).

For every protected request, the client sends that cookie back.

**protectRoute middleware**

Reads req.cookies.jwt

Verifies the token against JWT_SECRET_KEY

Fetches the user from MongoDB (omitting the password) and attaches it as req.user

Calls next() if valid, or returns 401 Unauthorized if missing/invalid token or no matching user

**POST /api/auth/onboarding (protected)**

Validates required fields: fullName, bio, yourBeliefsPhilosophy, curiousAbout, location

Returns 400 + missingFields array if any are blank

Updates the user (isOnboarded: true) and returns the updated document

Calls upsertStreamUser to sync profile changes to Stream Chat (errors are logged without blocking)

**GET /api/auth/me (protected)**

Returns the current user’s data

**Server setup**
Registered express.json() and cookie-parser() globally

Mounted all auth routes under /api/auth

**Error handling**

Wraps the Stream upsert in its own try/catch so onboarding still succeeds if StreamChat fails

Logs any errors from the Mongo update or StreamChat call and returns 500 only on unexpected failures

**Other changes**
logout remains a POST that clears the jwt cookie

The new GET /api/auth/me and existing signup/login/logout routes are all mounted under /api/auth and protected where appropriate

This fills out the full signup -> onboarding -> profile sync flow and ensures Stream Chat always has the latest user info.

