### PR TITLE
refactor(auth): extract login & signup logic into reusable hooks

### DIFF
--- a/frontend/src/hooks/useLogin.js
+++ b/frontend/src/hooks/useLogin.js
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { login } from '../lib/api';
+
+const useLogin = () => {
+  const queryClient = useQueryClient();
+
+  const {mutate, isPending, error} = useMutation({
+    mutationFn:login,
+    onSuccess:()=>queryClient.invalidateQueries({queryKey:["authUser"]})
+  });
+
+  return { error, isPending, loginMutation: mutate};
+};
+
+export default useLogin

--- a/frontend/src/hooks/useSignup.js
+++ b/frontend/src/hooks/useSignup.js
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { signup } from "../lib/api";
+  //once you create an account this method will run, then cal the mutate function just above, which sends a request 
+  // to our endpoint with the signup data we have, if everything goes successfully we'll refetch the onSuccess query
+  // the route path will be reevaluated and well be navigated to the homepage
+const useSignup = () => {
+  const queryClient = useQueryClient();
+
+
+  const {mutate, isPending, error} = useMutation({
+    mutationFn: signup,
+    //if everything goes successfully this function will fetch the authenticated user data so we're redirected
+    onSuccess: () => queryClient.invalidateQueries({queryKey: ["authUser"]}),
+
+
+  });   
+  return { isPending, error, signupMutation: mutate};
+
+};
+
+export default useSignup;

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,20 +1,16 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { BrainIcon } from 'lucide-react';
 import React, { useState } from 'react'
-import { login } from '../lib/api';
 import { Link } from "react-router";
+import useLogin from '../hooks/useLogin';
 const LoginPage = () => {
   const [loginData, setLoginData] = useState({
     email: "",
     password: "",
   });
 
-  const queryClient = useQueryClient();
+  const { isPending, error, loginMutation} = useLogin()
 
-  const {mutate:loginMutation, isPending, error} = useMutation({
-    mutationFn:login,
-    onSuccess:()=>queryClient.invalidateQueries({queryKey:["authUser"]})
-  });
+
 
   const handleLogin = (e) => {
     e.preventDefault();//so it doesn't refresh the page

--- a/frontend/src/pages/SignUpPage.jsx
+++ b/frontend/src/pages/SignUpPage.jsx
@@ -1,8 +1,8 @@
 import { useState }  from 'react'
 import { Brain } from "lucide-react";
 import {Link } from "react-router";
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { signup } from '../lib/api';
+import useSignup from '../hooks/useSignup';
+
 
 
 const SignUpPage = () => {
@@ -12,19 +12,9 @@ const SignUpPage = () => {
     password: "",
   });
 
-  const queryClient = useQueryClient();
 
+const {isPending, error,signupMutation} = useSignup();
 
-  const {mutate:signupMutation, isPending, error} = useMutation({
-    mutationFn: signup,
-    //if everything goes successfully this function will fetch the authenticated user data so we're redirected
-    onSuccess: () => queryClient.invalidateQueries({queryKey: ["authUser"]}),
-
-
-  });
-  //once you create an account this method will run, then cal the mutate function just above, which sends a request 
-  // to our endpoint with the signup data we have, if everything goes successfully we'll refetch the onSuccess query
-  // the route path will be reevaluated and well be navigated to the homepage
   const handleSignup = (e) => {
     e.preventDefault();
     signupMutation(signupData);


### PR DESCRIPTION
- Create `useLogin` hook to encapsulate React Query mutation for login
- Create `useSignup` hook to encapsulate React Query mutation for signup
- Update `LoginPage.jsx` to use `useLogin` instead of inline mutation logic
- Update `SignUpPage.jsx` to use `useSignup` instead of inline mutation logic

-done in case i want to easily change sign up and login implementations without interfering with the actual signup and login pages 