### PR TITLE
feat(theme): add dynamic theme selection

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,8 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hot-toast": "^2.5.2",
-        "react-router-dom": "^7.6.3"
+        "react-router-dom": "^7.6.3",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1495,7 +1496,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4511,6 +4512,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+      "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hot-toast": "^2.5.2",
-    "react-router-dom": "^7.6.3"
+    "react-router-dom": "^7.6.3",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,20 +10,23 @@ import { Toaster } from "react-hot-toast";
 import PageLoader from "./components/PageLoader.jsx";
 import useAuthUser from "./hooks/useAuthUser.js";
 import Layout from "./components/Layout.jsx";
+import { useThemeStore } from "./store/useThemeStore.js";
 
 //if user is authenticated, we'll check if they're onboarded, if they are not, navigate them to onboard page, if they are onboarded, they can go to whatever page they want. if they're not authenticated, we'll navigate them to login page. 
 const App = () => {
 
   const {isLoading, authUser} = useAuthUser();
+  const { theme } = useThemeStore();
+ 
 
-  const isAuthenticated = Boolean (authUser);
+  const isAuthenticated = Boolean(authUser);
   const isOnboarded = authUser?.isOnboarded;
 
 
   if (isLoading) return <PageLoader/>;
 
   return (
-  <div className= "h-screen" data-theme="night">
+  <div className="h-screen" data-theme={theme}>
     <Routes>
       <Route 
         path="/" 

--- a/frontend/src/components/ThemeSelector.jsx
+++ b/frontend/src/components/ThemeSelector.jsx
@@ -1,9 +1,51 @@
-import React from 'react'
+import { PaintBucketIcon, } from "lucide-react";
+import { useThemeStore } from "../store/useThemeStore";
+import { THEMES } from "../constants";
 
 const ThemeSelector = () => {
-  return (
-    <div>ThemeSelector</div>
-  )
+  const { theme, setTheme } = useThemeStore();
+  return <div className="dropdown dropdown-end">
+    {/* DROPDOWN TRIGGER */}
+    <button tabIndex={0} className="btn btn-ghost btn-circle">
+        <PaintBucketIcon className="size-5" />
+    </button>
+    <div
+       tabIndex = {0} 
+        className="dropdown-content mt-2 p-1 shadow-2xl bg-base-200 backdrop-blur-lg rounded-2xl w-56 border border-base-content/10 max-h-80 overflow-y-auto"
+    >
+        <div className="space-y-1">
+            {THEMES.map((themeOption) => (
+                <button key={themeOption.name}
+                className={` w-full px-4 py-3 rounded-xl flex items-center gap-3 transition-colors 
+            //dynamic part that says if the current theme is equal to the theme option then well add the first option else it will have the other 
+                ${
+                    theme === themeOption.name
+                      ? "bg-primary/10 text-primary"
+                      :"hover:bg-base-content/5"
+                }
+            `}
+            onClick={() => setTheme(themeOption.name)}
+            >
+                <PaintBucketIcon className="size-4" />
+                <span className="text-sm font-medium">{themeOption.name}</span>
+                {/* THEME PREVIEW COLORS */}
+                <div className="ml-auto flex gap-1">
+                    {themeOption.colors.map((color, i) => (
+                        <span
+                           key={i}
+                           className="size-2 rounded-full"
+                           style={{ backgroundColor: color}}
+                        />
+                    ))}
+                </div>
+
+
+                </button>
+             ))}
+        </div>
+    </div>
+  </div>
+
 }
 
 export default ThemeSelector

--- a/frontend/src/hooks/useLogin.js
+++ b/frontend/src/hooks/useLogin.js
@@ -12,4 +12,4 @@ const useLogin = () => {
   return { error, isPending, loginMutation: mutate};
 };
 
-export default useLogin
+export default useLogin;

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,9 +1,7 @@
-import React from 'react'
-
 const HomePage = () => {
-  return (
-    <div>HomePage</div>
-  )
-}
+
+  return <div>HomePage</div>
+
+};
 
 export default HomePage

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,5 +1,5 @@
 import { BrainIcon } from 'lucide-react';
-import React, { useState } from 'react'
+import  { useState } from 'react'
 import { Link } from "react-router";
 import useLogin from '../hooks/useLogin';
 const LoginPage = () => {
@@ -8,14 +8,14 @@ const LoginPage = () => {
     password: "",
   });
 
-  const { isPending, error, loginMutation} = useLogin()
+  const { isPending, error, loginMutation} = useLogin();
 
 
 
   const handleLogin = (e) => {
     e.preventDefault();//so it doesn't refresh the page
     loginMutation(loginData);
-  }
+  };
 
 
   return (

--- a/frontend/src/store/useThemeStore.js
+++ b/frontend/src/store/useThemeStore.js
@@ -1,0 +1,7 @@
+import { create } from 'zustand'
+
+export const useThemeStore = create((set) => ({
+    theme:localStorage.getItem("MindSwap-theme") || "synthwave",
+    setTheme: (theme) => {localStorage.setItem("MindSwap-theme", theme);
+    set({ theme })},
+}));


### PR DESCRIPTION
- Introduce `useThemeStore` (Zustand) to persist and retrieve current theme from `localStorage` so theme doesn't disappear after refreshing the page
- Bind App’s root `<div>` `data-theme` attribute to the theme value from the store
- Create `ThemeSelector` component with a dropdown of available THEMES and preview swatches
- Wire up `ThemeSelector` in the Navbar so users can switch themes at runtime