### PR TITLE
feat(homepage): implement friends & recommendations dashboard

### DIFF
--- a/backend/src/controllers/user.controller.js
+++ b/backend/src/controllers/user.controller.js
@@ -9,14 +9,14 @@ export async function getRecommendedUsers(req, res) {
         const currentUserId = req.user.id;
         const currentUser = req.user
 
-        const getRecommendedUsers = await User.find({
+        const recommendedUsers = await User.find({
             $and: [
                 {_id:{$ne: currentUserId}}, //exclude current user
-                {$id: {$nin: currentUser.friends}}, //exclude current user's friends
+                {_id: {$nin: currentUser.friends}}, //exclude current user's friends
                 {isOnboarded: true}// only want to see onboarded users
-            ]
-        })
-        res.status(200).json({recommendedUsers})
+            ],
+        });
+        res.status(200).json(recommendedUsers);
     } catch (error) {
         console.error("Error in getRecommendedUsers controller", error.message);
 
@@ -72,7 +72,7 @@ export async function sendFriendRequest(req, res) {
             return res.status(400).json({ message: "A friend request already exists between you and this user"});
         }
         //finally, if all those checks go through, create a friend request
-        const FriendRequest = await FriendRequest.create({
+        const newRequest = await FriendRequest.create({
             sender: myId,
             recipient: recipientId,
 
@@ -146,7 +146,7 @@ export async function getFriendRequests(req, res){
 
 export async function getOutgoingFriendReqs(req, res){
     try {
-        const outgoingRequests = await friendRequest.find({
+        const outgoingRequests = await FriendRequest.find({
             sender: req.user.id,
             status: "pending",
 

--- a/frontend/src/components/FriendCard.jsx
+++ b/frontend/src/components/FriendCard.jsx
@@ -1,0 +1,32 @@
+import {Link} from "react-router";
+const FriendCard = ({friend}) => {
+  return <div className="card bg-base-200 hover:shadow-md transition-shadow">
+    <div className="card-body p-4">
+        {/* USER INFO */}
+        <div className="flex items-center gap-3 mb-3">
+            <div className="avatar size-12">
+            <img src={friend.profilePic} alt={friend.fullName} />
+        </div>
+        <h3 className="font-semibold truncate">{friend.fullName}</h3>
+        </div>
+
+        {/* ACTIONS */}
+        <div className="flex flex-wrap gap-1.5 mb-3">
+            <span className="badge badge-secondary text-xs">
+                Your Beliefs/Philosophy : {friend.yourBeliefsPhilosphy}
+            </span>
+            <span className="badge badge-outline text-xs">
+                Curious About: {friend.curiousAbout}
+            </span>
+        </div>
+        <Link to={`/chat/${friend._id}`} className="btn btn-outline w-full">
+            Message
+        </Link>
+
+    </div>
+  </div>
+
+
+}
+
+export default FriendCard

--- a/frontend/src/components/NoFriends.jsx
+++ b/frontend/src/components/NoFriends.jsx
@@ -1,0 +1,12 @@
+const NoFriends = () => {
+  return (
+    <div className="card bg-base-200 p-6 text-center">
+        <h3 className="font-semibold text-lg mb-2">No friends yet</h3>
+        <p className="text-base-content opacity-70">
+            Find Peers to Challenge Your Worldview and Learn Something New!
+        </p>
+    </div>
+  );
+};
+
+export default NoFriends

--- a/frontend/src/components/PageLoader.jsx
+++ b/frontend/src/components/PageLoader.jsx
@@ -1,9 +1,10 @@
-import React from 'react'
 import { LoaderIcon } from "lucide-react"
+import { useThemeStore } from "../store/useThemeStore"
 
 const PageLoader = () => {
+  const {theme} = useThemeStore();
   return (
-    <div className="min-h-screen flex items-center justify-center">
+    <div className="min-h-screen flex items-center justify-center" data-theme={theme}>
         <LoaderIcon className="animate-spin size-10 text-primary" />
     </div>
   )

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -29,3 +29,20 @@ export const completeOnboarding = async (userData) => {
     const response = await axiosInstance.post("/auth/onboarding", userData);
     return response.data;
 };
+//send request to end point users to fetch the friends and or recommended users then return the data
+export async function getUserFriends(){
+  const response = await axiosInstance.get("/users/friends");
+  return response.data;
+}
+export async function getRecommendedUsers(){
+  const response = await axiosInstance.get("/users");
+  return response.data;
+}
+export async function getOutgoingFriendReqs(){
+  const response = await axiosInstance.get("/users/outgoing-friend-requests");
+  return response.data;
+}
+export async function sendFriendRequest(userId) {
+  const response = await axiosInstance.post(`/users/friend-request/${userId}`);
+  return response.data;
+}

--- a/frontend/src/lib/util.js
+++ b/frontend/src/lib/util.js
@@ -1,0 +1,1 @@
+export const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,7 +1,153 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link} from "react-router";
+import { getOutgoingFriendReqs, getRecommendedUsers, getUserFriends, sendFriendRequest } from "../lib/api";
+import {  UsersRoundIcon, EarthIcon, UserPlusIcon, CheckLineIcon } from "lucide-react";
+import {useEffect, useState} from "react";
+import FriendCard from "../components/FriendCard";
+import NoFriends from "../components/NoFriends";
+import { capitalize } from "../lib/util";
 const HomePage = () => {
+  const QueryClient = useQueryClient();
+  const [outgoingRequestsIds, setOutgoingRequestsIds] = useState(new Set());
+  const{data:friends=[], isLoading:loadingFriends} = useQuery({
+    queryKey: ["friends"],
+    queryFn: getUserFriends,
+  })
+  const{data:recommendedUsers=[], isLoading:loadingUsers} = useQuery({
+    queryKey: ["recommendedUsers"],
+    queryFn: getRecommendedUsers,
+  })
+  const{data: outgoingFriendReqs } = useQuery({
+    queryKey: ["outgoingFriendReqs"],
+    queryFn: getOutgoingFriendReqs,
+  })
 
-  return <div>HomePage</div>
+  const {mutate:sendRequestMutation, isPending} = useMutation({
+    mutationFn: sendFriendRequest,
+    onSuccess: () => QueryClient.invalidateQueries({ queryKey: ["outgoingFriendReqs"]}),
+  })
+  useEffect(() => {
+  const outgoingIds = new Set() 
+  if(outgoingFriendReqs && outgoingFriendReqs.length > 0){
+    outgoingFriendReqs.forEach((req) => {
+      outgoingIds.add(req.recipient._id)
+    })
+    setOutgoingRequestsIds(outgoingIds) }
+  }, [outgoingFriendReqs])
+  return (
+    <div className="p-4 sm:p-6 lg:p-8">
+      <div className="container mx-auto space-y-10">
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+          <h2 className="text-2xl sm:text-3xl font-bold tracking-tight">Your Friends</h2>
+          <Link to="/notifications" className="btn btn-outline btn-sm">
+            <UsersRoundIcon className="mr-2 size-4" />
+            Friend Requests
+          </Link>
+        </div>
+
+        {loadingFriends ? ( <div className="flex justify-center py-12">
+          <span className="loading loading-spinner loading-lg">
+
+          </span>
+          </div>): friends.length == 0 ? (
+            <NoFriends/>
+) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+              {friends.map((friend) => (
+                <FriendCard key={friend._id} friend={friend} />
+              ))}
+
+            </div>
+          )}
+
+          <section>
+          <div className="mb-6 sm:mb-8">
+            <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+              <div>
+                <h2 className="text-2xl sm:text-3xl font-bold tracking-tight"> Meet Fellow Thinkers </h2>
+                <p className="opacity-70">
+                  Find people with different perspectives than yours
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {loadingUsers ? (<div className="flex justify-center py-12">
+          <span className="loading loading-spinner loading-lg"/>
+          </div>) : recommendedUsers.length === 0 ? (
+                    <div className="card bg-base-200 p-6 text-center">
+                      <h3 className="font-semibold text-lg mb-2">No recommendations available</h3>
+                      <p className="text-base-content opacity-70">
+                        Check back later for new thinkers!
+                      </p>
+                    </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {recommendedUsers.map((user) => {
+
+                const hasRequestBeenSent = outgoingRequestsIds.has(user._id);
+
+                return (
+                  <div key={user._id} className="card bg-base-200 hover:shadow-lg transition-all duration-300">
+                    <div className="card-body p-5 space-y-4">
+                      <div className="flex items-center gap-3">
+                      <div className="avatar size-16 rounded-full">
+                        <img src={user.profilePic} alt={user.fullName} />
+                      </div>
+                        <h3 className="font-semibold text-lg">{user.fullName}</h3>
+                        {user.location && (
+                          <div className="flex items-center text-xs opacity-70 mt-1">
+                            <EarthIcon className="size-3 mr-1" />
+                            {user.location}
+                          </div>
+                        )}
+                    </div>
+
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                <span className="badge badge-secondary">
+                  Beliefs/Philosophy: {capitalize(user.yourBeliefsPhilosophy)}
+                </span>
+                <span className="badge badge-outline">
+                  Curious About: {capitalize(user.curiousAbout)}
+                </span>
+              </div>
+              {user.bio && <p className="text-sm opacity-70"> {user.bio}</p>}
+
+              {/* Action Button : button with a class name that works such that if a request has already been sent, it will be disabled else it'll be primary
+               and then on click we're gonna call our sendRequestMutation with the argument (our user id) and this will be disabled if the request has already been sent or if we are in the pending state. and if the request has been sent
+               we're gonna see the user check icon from lucide react as well as a request sent message else we'll see the userplus icon from lucide dev as well as a send friend request message */}
+              <button 
+                className={`btn w-full mt-2 ${
+                  hasRequestBeenSent ? "btn-disabled" : "btn-primary"
+                }`}
+                onClick={() => sendRequestMutation(user._id)}
+                disabled = {hasRequestBeenSent || isPending}
+                >
+                  {hasRequestBeenSent ? ( 
+                    <>
+                      <CheckLineIcon className="size-4 mr-2" />
+                      Request Sent
+                  </>) : (
+                    <>
+                      <UserPlusIcon className="size-4 mr-2" />
+                      Send Friend Request
+                    </>
+                  )}
+                </button>
+            </div>
+
+                )
+              })}
+            </div>
+        ) }
+
+      </section>
+    </div>
+  </div>
+)
 
 };
 
 export default HomePage
+


### PR DESCRIPTION
- Create HomePage with two sections: “Your Friends” and “Meet Fellow Thinkers”
- Fetch data via React Query: user’s friends, outgoing friend requests, and recommended users
- Display friends in a grid using `FriendCard`; show `NoFriends` placeholder when none exist
- Add “Friend Requests” button linking to notifications
- Render recommended thinkers with profile, location, badges, and bio
- Wire up “Send Friend Request” button with disabled state for pending/outgoing requests
- Track outgoing request IDs in state and update on mutation success
- Show loading spinners (PageLoader) while queries are fetching
- Add `capitalize` util for consistent badge text formatting