### PR TITLE
feat(notifications): add Notifications center with incoming/outgoing friend-request workflow

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -44,7 +44,13 @@ const App = () => {
       <Route path="/signup" element={!isAuthenticated ? <SignUpPage />: <Navigate to ={isOnboarded ? "/" : "/onboarding"} />} />
       //if user is authenticated, show them the login page, else take them to the homepage or the onboarding page
       <Route path="/login" element={!isAuthenticated ? <LoginPage /> : <Navigate to ={isOnboarded ? "/" : "/onboarding"} />} />
-      <Route path="/notifications" element={isAuthenticated ? <NotificationsPage /> : <Navigate to ="/login" />} />
+      <Route path="/notifications" element={isAuthenticated && isOnboarded ? (
+        <Layout showSidebar>
+          <NotificationsPage />
+        </Layout>
+      ) : (
+        <Navigate to={!isAuthenticated ? "/login" : "/onboarding"}/>
+      )  } />
       <Route path="/call" element={isAuthenticated ? <CallPage /> : <Navigate to ="/login" />} />
       <Route path="/chat" element={isAuthenticated ? <ChatPage /> : <Navigate to ="/login" />} />
       <Route path="/onboarding" element={isAuthenticated ? ( !isOnboarded ? (<OnboardingPage />):(

--- a/frontend/src/components/NoNotificationsFound.jsx
+++ b/frontend/src/components/NoNotificationsFound.jsx
@@ -1,0 +1,17 @@
+import {  BellOffIcon } from "lucide-react";
+
+function NoNotificationsFound() {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <div className="size-16 rounded-full bg-base-300 flex items-center justify-center mb-4">
+        <BellOffIcon className="size-8 text-base-content opacity-40" />
+      </div>
+      <h3 className="text-lg font-semibold mb-2">No notifications yet</h3>
+      <p className="text-base-content opacity-70 max-w-md">
+        When you receive friend requests or messages, they'll appear here.
+      </p>
+    </div>
+  );
+}
+
+export default NoNotificationsFound;

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -46,3 +46,11 @@ export async function sendFriendRequest(userId) {
   const response = await axiosInstance.post(`/users/friend-request/${userId}`);
   return response.data;
 }
+export async function getFriendRequests(){
+  const response = await axiosInstance.get("/users/friend-requests");
+  return response.data;
+}
+export async function acceptFriendRequest(requestId){
+  const response = await axiosInstance.put(`/users/friend-request/${requestId}/accept`);
+  return response.data;
+}

--- a/frontend/src/pages/NotificationsPage.jsx
+++ b/frontend/src/pages/NotificationsPage.jsx
@@ -1,9 +1,140 @@
-import React from 'react'
+import { useMutation, useQueryClient , useQuery} from "@tanstack/react-query"
+import { acceptFriendRequest, getFriendRequests } from "../lib/api";
+import {  BellIcon, BellOffIcon, ClockIcon, MessageSquareIcon, UserRoundCheckIcon } from "lucide-react";
+import NoNotificationsFound from "../components/NoNotificationsFound";
+
+
 
 const NotificationsPage = () => {
-  return (
-    <div>NotificationsPage</div>
-  )
-}
 
+  const queryClient = useQueryClient();
+  const {data:friendRequests, isLoading} = useQuery({
+    queryKey: ["friendRequests"],
+    queryFn: getFriendRequests,
+  })
+
+  const {mutate: acceptRequestMutation, isPending} = useMutation({
+    mutationFn: acceptFriendRequest,
+ 
+    onSuccess: () => {
+ /* {once you accept the friend request it should immediately remove the friend request from the notifications page, and it should then show up in the your friends ui part of the home page, thus invalidate query} */
+      queryClient.invalidateQueries({ queryKey: ["friendRequests"] });
+      queryClient.invalidateQueries({ queryKey: ["friends"] });
+    
+    },
+
+
+  });
+
+  const incomingRequests = friendRequests?.incomingReqs || []
+  const acceptedRequests = friendRequests?.acceptedReqs || []
+
+  return (
+    <div className="p-4 sm:p-6 lg:p-8">
+      <div className="container mx-auto max-w-4xl space-y-8">
+      <h1 className="text-2xl sm:text-3xl font-bold tracking-tight mb-6">Notifications</h1>
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+        <span className="loading loading-spinner loading-lg"></span>
+        </div>
+      ): (
+        <>
+          {incomingRequests.length > 0 && (
+            <section className="space-y-4">
+              <h2 className="text-xl font-semibold flex items-center gap-2">
+                <UserRoundCheckIcon className="h-5 w-5 text-primary"/>
+                Friend Requests 
+                <span className="badge badge-primary ml-2">{incomingRequests.length}</span>
+              </h2>
+              <div className="space-y-3">
+                {incomingRequests.map((request) => (
+                  <div
+                    key={request._id}
+                    className="card bg-base-200 shadow-sm hover:shadow-md transition-shadow"
+                  > 
+                    <div className="card-body p-4">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-3">
+                            <div className="avatar w-14 h-14 rounded-full bg-base-300">
+                              <img src={request.sender.profilePic} alt={request.sender.fullName} />
+                            </div>
+                            <div>
+                              <h3 className="font-semibold">{request.sender.fullName}</h3>
+                              <div className="flex flex-wrap gap-1.5 mt-1">
+                                <span className="badge badge-secondary badge-sm">
+                                  Beliefs/Philosophy: {request.sender.yourBeliefsPhilosophy}
+                                </span>
+                                <span className="badge badge-outline badge-sm">
+                                  Curious About: {request.sender.curiousAbout}
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+
+                          <button className="btn btn-primary btn-sm"
+                            onClick={() => acceptRequestMutation(request._id)}
+                            disabled={isPending}
+                          >
+                            Accept
+
+                          </button>
+                      </div>
+                    </div>
+                  </div>
+
+                ))}
+
+              </div>
+
+            </section>
+
+          )}  
+
+          {/* ACCEPTED REQUESTS NOTIFICATIONS */}
+            {acceptedRequests.length > 0 && (
+              <section className="space-y-4">
+                <h2 className="text-xl font-semibold flex items-center gap-2">
+                  <BellIcon className="h-5 w-5 text-success" />
+                  New Connections
+                </h2>
+{              /* For accepted requests, we want to go through every single one and get their profile pic and full name */}
+                <div className="space-y-3">
+                  {acceptedRequests.map((notification) => (
+                    <div key={notification._id} className="card bg-base-200 shadow-sm">
+                      <div className="card-body p-4">
+                        <div className="flex items-start gap-3">
+                          <div className="avatar mt-1 size-10 rounded-full">
+                            <img
+                              src={notification.recipient.profilePic}
+                              alt={notification.recipient.fullName}
+                            />
+                          </div>
+                          <div className="flex-1">
+                            <h3 className="font-semibold">{notification.recipient.fullName}</h3>
+                            <p className="text-sm my-1">
+                              {notification.recipient.fullName} accepted your friend request
+                            </p>
+                            <p className="text-xs flex items-center opacity-70">
+                              <ClockIcon className="h-3 w-3 mr-1" />
+                              Recently
+                            </p>
+                          </div>
+                          <div className="badge badge-success">
+                            <MessageSquareIcon className="h-3 w-3 mr-1" />
+                            New Friend
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )}
+            {incomingRequests.length === 0 && acceptedRequests.length === 0 && (<NoNotificationsFound/>)}
+           </>
+          )}
+        </div>
+    </div>
+  );
+};
 export default NotificationsPage


### PR DESCRIPTION
- Register `/notifications` route in App.jsx, wrapped in Layout with sidebar
- Create `NotificationPage` component to:
  - Fetch incoming/pending and accepted friend requests via `getFriendRequests`
  - Render request cards with user info, such as the user's full name, avatar, beliefs/philosophy, location, and the belief/philosophy the requesting user is interested in, and “Accept” actions button that allows friend request recipient to accept the friend request, at which point the friend request is immediately removed from the notifications dashboard and the accepted friend now is added to the "your friends"  dashboard of the home page
  - Show loading spinners while queries run
- Implement `acceptFriendRequest` API call and React Query mutation to update request status
- Invalidate relevant queries on success so the UI updates immediately 
  - (e.g once you accept the friend request it should immediately remove the friend request from the notifications page, and the accepted friend should then show up in the your friends dashboard  part of the home page)
- Add `NoNotificationsFound` placeholder component for when no requests exist  
- Extend `lib/api.js` with:
  - `getFriendRequests()` -> GET `/users/friend-requests`
  - `acceptFriendRequest(requestId)` -> PUT `/users/friend-request/{id}/accept`