### PR TITLE
chore(deployment): configure static asset serving, CORS & monorepo scripts

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,15 +1,16 @@
 {
   "name": "backend",
   "version": "1.0.0",
-  "description": "",
   "main": "src/server.js",
   "scripts": {
-    "dev": "nodemon src/server.js"
+    "dev": "nodemon src/server.js",
+    "start": "node src/server.js"
   },
   "keywords": [],
   "author": "",
+  "type": "module",  
   "license": "ISC",
-  "type": "module",
+  "description": "",
   "dependencies": {
     "bcryptjs": "^3.0.2",
     "cookie-parser": "^1.4.7",

--- a/backend/src/routes/auth.route.js
+++ b/backend/src/routes/auth.route.js
@@ -1,4 +1,4 @@
-import express, { Router } from "express"
+import express from "express"
 import { login, logout, signup , onboard} from "../controllers/auth.controller.js";
 import { protectRoute } from "../middleware/auth.middleware.js"; 
 const router = express.Router();

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -2,9 +2,11 @@ import express from "express";
 import "dotenv/config";
 import cookieParser from "cookie-parser";
 import cors from "cors";
+import path from "path";
 import authRoutes from "./routes/auth.route.js";
 import userRoutes from "./routes/user.route.js";
 import chatRoutes from "./routes/chat.route.js";
+
 
 
 import { connectDB } from "./lib/db.js";
@@ -12,6 +14,7 @@ import { connectDB } from "./lib/db.js";
 const app = express();
 
 const PORT = process.env.PORT;
+const __dirname = path.resolve();
 app.use(cors({
     origin : "http://localhost:5173",
     credentials: true // allow frontend to send cookies
@@ -25,7 +28,17 @@ app.use(cookieParser());
 app.use("/api/auth", authRoutes);
 app.use("/api/users", userRoutes);
 app.use("/api/chat", chatRoutes);
-
+/*when we visit our application, we'll be able to serve both our api and our react application, so whenever we hit the above api endpoints (auth, users,chat), we're gonna
+we're going to return the related functions (authRoutes, userRoutes, chatRoutes), but if we hit any other routes, we'll serve our react application, which is coming from the index.html file  */
+//if in the production/deployed environment, take the dist folder from the front end, convert it to our static assests
+if(process.env.NODE_ENV === "production"){
+    //from the current backend directory, go into the front end and into the dist folder
+    app.use(express.static(path.join(__dirname, "../frontend/dist")));
+    //any routes other than auth, users, chat should return our react application
+    app.get("*", (req, res) => {
+        res.sendFile(path.join(__dirname, "../frontend", "dist", "index.html"));
+    });
+}
 app.listen(PORT, () => { 
     console.log(`Server is running on port ${PORT}`);
     connectDB();

--- a/frontend/src/lib/axios.js
+++ b/frontend/src/lib/axios.js
@@ -1,7 +1,11 @@
 import axios from "axios";
 
+//making url dynamic because not sure what it will be on deployment
+//if the base url is equal to development then we can just paste the local host
+const BASE_URL = import.meta.env.MODE === "development" ? "http://localhost:5001/api" : "/api";
+
 export const axiosInstance = axios.create({
-    baseURL: "http://localhost:5001/api",
+    baseURL: BASE_URL,
     withCredentials: true, //send cookies with the request
 
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "video-call-chat-app",
+  "name": "mindswap",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}

--- a/package.json
+++ b/package.json
@@ -1,1 +1,13 @@
-{}
+{
+  "name": "mindswap",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "build": "npm install --prefix backend && npm install --prefix frontend && npm run build --prefix frontend",
+    "start": "npm run start --prefix backend"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}


### PR DESCRIPTION


- Add root `package.json` with `build` (installs & builds frontend) and `start` (runs backend) for monorepo CI/CD
- Serve `frontend/dist` as static assets and fallback all other routes to `index.html`
- Update `frontend/src/lib/axios.js` to use a dynamic `baseURL` (`import.meta.env.VITE_API_URL || '/api'`) and `withCredentials: true`
- Install and configure `cookie-parser` and `dotenv` to support auth cookie flows in production